### PR TITLE
Fix issue #111

### DIFF
--- a/themes/default/static/js/notepad.js
+++ b/themes/default/static/js/notepad.js
@@ -72,6 +72,6 @@ var notepad = (function ($) {
 
 })(jQuery);
 
-(function () {
+$(document).ready(function() {
     notepad.init();
-})();
+});


### PR DESCRIPTION
O js do menu é inicializado dentro do  `$(document).ready`. Ele era chamado no momento em que o  ícone de menu mobile ainda não existia na página.
