### PR TITLE
Fix issue #60

### DIFF
--- a/themes/default/static/css/post.css
+++ b/themes/default/static/css/post.css
@@ -441,7 +441,8 @@ html, body, .notepad-post-container, .notepad-post-header {
     padding-bottom: 2.5rem; }
     .notepad-page-title .notepad-post-meta-simple h1,
     .notepad-post-title-simple .notepad-post-meta-simple h1 {
-      padding: 0; }
+      padding: 0;
+      word-wrap: break-word; }
     .notepad-page-title .notepad-post-meta-simple p.meta,
     .notepad-post-title-simple .notepad-post-meta-simple p.meta {
       padding-top: 0.625rem; }


### PR DESCRIPTION
Não é a melhor solução, mas título grande é sempre um problema.
Adicionei a regra de css  `word-wrap: break-word` no titulo do post, assim a palavra quebra linha e não fica pra fora do grid.
