### PR TITLE
Add link to location name only when it has an url

### DIFF
--- a/themes/default/static/css/style.css
+++ b/themes/default/static/css/style.css
@@ -149,7 +149,12 @@ html, body {
 
 .location-name {
   font-size: 16px;
-  padding: 0 15px;
+}
+
+.location-external-link {
+  font-size: 12px;
+  vertical-align: middle;
+  padding-left: 2px;
 }
 
 .lady-name {

--- a/themes/default/templates/locations.html
+++ b/themes/default/templates/locations.html
@@ -15,11 +15,14 @@
               <div>
                 <img class="img-location" src="{{ SITEURL }}{{ location.image }}">
               </div>
+              {% if location.url %}
               <a target="_blank" href="{{ location.url }}">
-                <span class="location-name">
-                  Pyladies {{ location.city }}
-                </span>
+                <span class="location-name">Pyladies {{ location.city }}</span>
+                <i class="fa fa-external-link location-external-link" aria-hidden="true"></i>
               </a>
+              {% else %}
+                <span class="location-name">Pyladies {{ location.city }}</span>
+              {% endif %}
               <div class="social-icons">
                 {% if location.twitter %}
                 <a target="_blank" href="{{ location.twitter }}">


### PR DESCRIPTION
Today, even when a location doesn't have an external link we add an `a` tag to location's name, creating a weird behavior, because you click it and it goes nowhere.
I've changed that to add a link only when the location has an url. I also added an "external link" icon to make explicit when a location has an url.
I did something similar at #134 
