### PR TITLE
Adiciona um comando para carregar eventos do Facebook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,16 +78,31 @@ Se tudo deu certo, sua página já estará disponível em `/slug-pagina/`.
 Adicionar Eventos
 -----------------
 
-Para adicionar novos eventos, basta editar o arquivo `data/events.yml` . Ele possui o seguinte formato:
+Existem duas formas de incluir eventos no site, manualmente e através de um evento no Facebook.
+
+Para adicionar novos eventos manualmente, basta editar o arquivo `data/events.yml`. Ele possui o seguinte formato:
 
 ```yaml
 - url: URL DO SEU EVENTO
   name: NOME DO EVENTO
   date: DATA EVENTO (Formato DD-MM-YYYY)
   local: LOCAL EVENTO
+  facebook_id: ID DO EVENTO NO FACEBOOK (se houver)
 ```
 
 Caso o evento seja novo, ele será automaticamente inserido em Novos Eventos. Caso contrário, já ficará na lista de Eventos passados.
+
+É possível também importar os eventos do Facebook de páginas de grupos PyLadies espalhados pelo Brasil, para isso, primeiramente verifique se o ID do Facebook da página do seu grupo (aquele que aparece na URL quando acessado) se encontra na listagem de grupos em `utils/__init__.py`.
+
+O próximo passo é obter um token de acesso do Facebook para o seu usuário. Você pode facilmente obte-lo no link https://developers.facebook.com/tools/explorer e copiando o campo "Token de acesso". Não compartilhe seu token de usuário com outras pessoas.
+
+Em seguida, abra uma linha de comando e atribua seu token a uma variável de ambiente com o comando (não esqueça as aspas):
+
+    export FACEBOOK_TOKEN="{seu-token}"
+
+Agora é só rodar o comando abaixo, lembrando que o conteúdo gerado é estático, ou seja, para atualizá-lo é necessário re-executar o comando:
+
+    make load-facebook-events
 
 
 Adicionar Ladies

--- a/Makefile
+++ b/Makefile
@@ -144,5 +144,8 @@ endif
 virtualenv:
 	$(VIRTUALENV) $(VENV)
 
+load-facebook-events:
+	$(PY) -c "import utils; utils.load_facebook_events(utils.PYLADIES_FACEBOOK_PAGES)"
+
 
 .PHONY: up html help clean regenerate serve serve-global devserver publish github newpost newpage

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ help:
 	@echo '   make stopserver                     stop local server                  '
 	@echo '   make github                         upload the web site via gh-pages   '
 	@echo '   make virtualenv                     create default virtual environment '
+	@echo '   make load-facebook-events           load events from known FB pages    '
 	@echo '                                                                          '
 	@echo 'Set the DEBUG variable to 1 to enable debugging, e.g. make DEBUG=1 html   '
 	@echo 'Set the RELATIVE variable to 1 to enable relative urls                    '

--- a/data/events.yml
+++ b/data/events.yml
@@ -95,3 +95,136 @@
   name: I PyLadies Natal
   date: 02-04-2014
   local: IFRN - Natal
+
+- date: 07-09-2016
+  facebook_id: '168681043566980'
+  local: Avenue Code
+  name: Curso gratuito de programação em Python + Flask para mulheres
+  url: https://facebook.com/168681043566980
+
+- date: 27-08-2016
+  facebook_id: '201000006982677'
+  local: ''
+  name: Curso Iniciante de progamação em Python (Gratuito)
+  url: https://facebook.com/201000006982677
+
+- date: 13-08-2016
+  facebook_id: '235857383480513'
+  local: Faculdade BandTec
+  name: Curso básico de programação em Python para Pais e Filhos
+  url: https://facebook.com/235857383480513
+
+- date: 30-07-2016
+  facebook_id: '1732909306967092'
+  local: Alameda Santos, 1293 Conj 73 - Jardim Paulista São Paulo SP
+  name: 'Curso gratuito intermediário I de programação em Python para mulheres '
+  url: https://facebook.com/1732909306967092
+
+- date: 01-10-2016
+  facebook_id: '596540730520562'
+  local: Feec Unicamp
+  name: Workshop básico de programação
+  url: https://facebook.com/596540730520562
+
+- date: 08-03-2017
+  facebook_id: '1255132404605803'
+  local: Teresina Hacker Clube
+  name: Semana da Mulher na Tecnologia em Teresina
+  url: https://facebook.com/1255132404605803
+
+- date: 09-04-2016
+  facebook_id: '1536643663298251'
+  local: CEDEMP - R. Tsunessaburo Makiguti, 157 Floradas de São José, zona sul, São
+    José dos Campos 12223000, Brazil
+  name: 1º PyLadies Vale
+  url: https://facebook.com/1536643663298251
+
+- date: 11-03-2017
+  facebook_id: '758449464308577'
+  local: parque de Coqueiros - Florianópolis
+  name: 'Technic: piquenique da comunidade das mulheres de TI'
+  url: https://facebook.com/758449464308577
+
+- date: 15-09-2016
+  facebook_id: '330544317293452'
+  local: Associação Catarinense de Empresas de Tecnologia - Acate
+  name: Encontro Pyladies Floripa
+  url: https://facebook.com/330544317293452
+
+- date: 10-03-2016
+  facebook_id: '979445105457411'
+  local: Contentools Brasil
+  name: 3o Encontro Pyladies Floripa
+  url: https://facebook.com/979445105457411
+
+- date: 30-01-2016
+  facebook_id: '1660347674205807'
+  local: Ecentry - Sala 201 - R. Emílio Blum, 131 - Centro, Florianópolis - SC
+  name: 2o Encontro Pyladies Floripa
+  url: https://facebook.com/1660347674205807
+
+- date: 21-03-2016
+  facebook_id: '247065545627023'
+  local: DC/UFSCar
+  name: Apresentação do PyLadies São Carlos
+  url: https://facebook.com/247065545627023
+
+- date: 09-03-2016
+  facebook_id: '1734466206800267'
+  local: ICMC - USP
+  name: 'Dojo PyLadies São Carlos: Semana da Mulher'
+  url: https://facebook.com/1734466206800267
+
+- date: 08-10-2016
+  facebook_id: '1640008716309290'
+  local: Avenida Almirante Maximiniano da Fonseca, Fortaleza - CE, 60811-020, Brasil
+  name: Byte Girl
+  url: https://facebook.com/1640008716309290
+
+- date: 12-03-2016
+  facebook_id: '1234552596574177'
+  local: Casa Da Cultura Digital
+  name: Ocupação Pyladies na CCD
+  url: https://facebook.com/1234552596574177
+
+- date: 12-02-2017
+  facebook_id: '1857177814563464'
+  local: Parque Lage, Rio de Janeiro.
+  name: Piquenique PyLadies
+  url: https://facebook.com/1857177814563464
+
+- date: 23-07-2016
+  facebook_id: '302357120098757'
+  local: Starbucks - Nova América
+  name: Python Café Cookies
+  url: https://facebook.com/302357120098757
+
+- date: 12-11-2016
+  facebook_id: '1022432631201205'
+  local: Cesupa - Unidade José Malcher
+  name: 'Minicurso: Introdução á programação com Python para mulheres'
+  url: https://facebook.com/1022432631201205
+
+- date: 16-12-2016
+  facebook_id: '1635441080089871'
+  local: Raul Hacker Club
+  name: É Verão, Py!
+  url: https://facebook.com/1635441080089871
+
+- date: 10-12-2016
+  facebook_id: '541965545928248'
+  local: Faculdade Ruy Barbosa - Campus Rio Vermelho
+  name: PyLadies SSA Convidam
+  url: https://facebook.com/541965545928248
+
+- date: 30-04-2016
+  facebook_id: '538598909680005'
+  local: Raul Hacker Club
+  name: PyLadies Meetup - Web Design descomplicado
+  url: https://facebook.com/538598909680005
+
+- date: 06-03-2016
+  facebook_id: '1174083145950381'
+  local: Raul Hacker Club
+  name: Meetup PyLadies Salvador
+  url: https://facebook.com/1174083145950381

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Markdown==2.6.7
 ghp-import==0.4.1
 PyYAML==3.12
 beautifulsoup4==4.5.1
+facebook-sdk==2.0.0

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,89 @@
+import os
+from datetime import datetime
+
+import yaml
+from facebook import GraphAPI
+
+
+PYLADIES_FACEBOOK_PAGES = [
+    'pyladies',
+    'PyLadiesBrazil',
+    'PyLadiesSP',
+    'pyladiescps',
+    'PyLadiesTeresina',
+    'PyLadiesNatal',
+    'PyLadiesDuqueDeCaxias',
+    'pyladiesvale',
+    'pyladiesfloripa',
+    'PyLadiesCuritiba',
+    'pyladiesdf',
+    'pyladiesrp',
+    'PyLadiesSaoCarlos',
+    'pyladiesbh',
+    'pyladiespucrio',
+    'PyLadiesFortaleza',
+    'pyLadiesPHB',
+    'fundao.pyladies',
+    'pyladiesrio',
+    'PyLadiesPicos',
+    'pyladiesbelem',
+    'PyLadiesSalvador',
+    'pyladiesrecife',
+    'PyLadiesMaceio',
+    'pyladiespoa',
+    'PyLadiesSLZ',
+]
+
+
+def load_facebook_events(nodes, token=os.environ.get('FACEBOOK_TOKEN')):
+    """
+    Load events from Facebook pages to the events file.
+
+    ..important:
+
+        In order for this function to work, you need to to provide a valid
+        Facebook Graph API token. You can get yours easily on
+        https://developers.facebook.com/tools/explorer
+
+    :param nodes: Facebook nodes to load public events from.
+    :param token: Facebook Graph API token.
+    """
+
+    # Facebook settings
+    graph = GraphAPI(access_token=token)
+
+    with open('data/events.yml', 'r') as events_file:
+        existing_events = yaml.load(events_file)
+
+    # Get facebook metadata on existing entries
+    facebook_ids = {entry.get('facebook-id') for entry in existing_events}
+
+    fetched_events = []
+
+    for node in nodes:
+        event_node = "{}/events".format(node)
+        node_events = graph.get_object(event_node, limit=1000)
+
+        for event in node_events['data']:
+
+            # If event already exists, just ignore
+            if event['id'] in facebook_ids:
+                continue
+
+            format_date = datetime.strptime(event['start_time'],
+                                            '%Y-%m-%dT%H:%M:%S%z')
+
+            fetched_events.append({
+                'name': event['name'],
+                'url': 'https://facebook.com/{}'.format(event['id']),
+                'local': event.get('place', {}).get('name', ''),
+                'date': format_date.strftime('%d-%m-%Y'),
+                'facebook_id': str(event['id'])
+            })
+
+    with open('data/events.yml', 'a') as events_file:
+        for entry in fetched_events:
+            events_file.write('\n')
+            yaml.dump([entry], events_file,
+                      default_flow_style=False,
+                      allow_unicode=True)


### PR DESCRIPTION
Wait for #157 

Ideia mencionada no grupo do Telegram.

Para carregar os eventos do Facebook, basta obter um token de acesso, designa-lo a uma variável de ambiente e executar:

```
make load-facebook-events
```

Mais detalhes na documentação.

PS: não esqueçam de atualizar os requirements com `make install` ou da forma que preferirem. :)

r? @darlenedms @pgrangeiro