### PR TITLE
Creates new blog post - last sponsor advertorial

### DIFF
--- a/content/2017-10-08-publieditorial-trans-code.md
+++ b/content/2017-10-08-publieditorial-trans-code.md
@@ -19,6 +19,7 @@ Sabemos o quanto é importante para o aprendizado de programação que o primeir
 Novos eventos em novos lugares são bem-vindos! Conheça melhor o projeto no http://trans.tech e [twitter.com/trans_code](http://www.twitter.com/trans_code), e organize você também uma edição na sua localidade!
 
 ![Trans Code 2016]({filename}/images/trans-code/20160423_143037.jpg)
+
 ![Trans Code 2016]({filename}/images/trans-code/20160423_142941.jpg)
 
 Este publieditorial é um agradecimento nosso e parte da recompensa pela cota de patrocínio oferecida pela professora Naomi Ceder.

--- a/content/2017-10-14-publieditorial-avelino.md
+++ b/content/2017-10-14-publieditorial-avelino.md
@@ -10,9 +10,9 @@ Infelizmente a 13ª edição da <b>Python Brasil</b> chegou ao fim e as PyLadies
 
 ![Avelino]({filename}/images/avelino.jpg)
 
-Prolífico colaborador open source desde muito jovem, <b>Thiago Avelino</b> é referência na comunidade Python e especialista em inteligência artificial, redes neurais e na linguagem Go, de cujo time desenvolvedor fez parte. Colaborou com vários projetos que a gente ama, como o próprio Django (❤). Obrigada por isso também, Avelino!
+Prolífico colaborador open source desde muito jovem, <b>Thiago Avelino</b> é referência na comunidade Python e especialista em inteligência artificial, redes neurais e na linguagem Go, de cujo time desenvolvedor fez parte. Colaborou com vários projetos que a gente ama, como o próprio <b>Django</b> (❤). Obrigada por isso também, Avelino!
 
-Gente boa, incentivador da diversidade em tech, é fundador e CTO da [Nuveo](https://nuveo.ai/). Está contratando e não perde uma <b>PyBR</b> para encontrar pessoas que possam dar "match" com a empresa.
+Gente fina, é fundador e CTO da [Nuveo](https://nuveo.ai/), que hoje tem a diversidade na rota de melhorias. Está contratando e não perde uma <b>PyBR</b> para encontrar pessoas que possam dar "match" com a empresa.
 
 Acompanhe o trabalho do Avelino no [Twitter](https://twitter.com/avelino0) e no [Github](https://github.com/avelino).
 

--- a/content/2017-10-14-publieditorial-avelino.md
+++ b/content/2017-10-14-publieditorial-avelino.md
@@ -1,0 +1,19 @@
+Title: Obrigada, Avelino!
+Slug: publieditorial-avelino
+Date: 2017-10-14 13:56:28
+Tags: eventos, PyBR, Avelino, Nuveo
+Category: Publieditorial
+author: Letícia Monteiro
+comments: true
+
+Infelizmente a 13ª edição da <b>Python Brasil</b> chegou ao fim e as PyLadies de fora de Belo Horizonte já voltaram para casa. Na bagagem tanto de quem foi como de quem fica, novos conhecimentos, experiências, amizades, saudades e muita gratidão. Cada palestra, cada tutorial que ministramos e assistimos, cada projeto com que colaboramos e pythonista com quem pareamos, cada troca certamente nos tornou programadoras e pessoas melhores. Por tudo isso, temos muito a agradecer a todas as pessoas e empresas que nos apoiaram contribuindo ou divulgando a [campanha de financiamento coletivo](http://brasil.pyladies.com/2017/08/30/campanha-pyladies-no-pybr-13-reta-final) que possibilitou a viagem de *todas* as PyLadies que não poderiam ter participado sem auxílio financeiro. Dedicamos um agradecimento mais do que especial a quem nos apoiou com a maior cota de patrocínio: o <b>Avelino</b>, a [Naomi Ceder](http://brasil.pyladies.com/2017/10/07/publieditorial-naomi-ceder/) e a [Labcodes](http://brasil.pyladies.com/2017/10/06/publieditorial-labcodes/). Sua contribuição foi fundamental para este capítulo da nossa história.
+
+![Avelino]({filename}/images/avelino.jpg)
+
+Prolífico colaborador open source desde muito jovem, <b>Thiago Avelino</b> é referência na comunidade Python e especialista em inteligência artificial, redes neurais e na linguagem Go, de cujo time desenvolvedor fez parte. Colaborou com vários projetos que a gente ama, como o próprio Django (❤). Obrigada por isso também, Avelino!
+
+Gente boa, incentivador da diversidade em tech, é fundador e CTO da [Nuveo](https://nuveo.ai/). Está contratando e não perde uma <b>PyBR</b> para encontrar pessoas que possam dar "match" com a empresa.
+
+Acompanhe o trabalho do Avelino no [Twitter](https://twitter.com/avelino0) e no [Github](https://github.com/avelino).
+
+Este publieditorial é um agradecimento nosso e parte da recompensa pela cota de patrocínio oferecida pelo Avelino.


### PR DESCRIPTION
Terceiro e último publieditorial que faz parte da recompensa pela contribuição com a maior cota de patrocínio na campanha de financiamento coletivo da viagem das PyLadies para a Python Brasil 13. Avelino, o aṕoiador em questão, respondeu ao nosso e-mail sobre o conteúdo do publieditorial apenas com nome, foto e links para Twitter e Github. Demais informações foram fruto de pesquisa para enriquecer o conteúdo do texto.