### PR TITLE
[fix] Clarifing that command make install should be done outside any vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Instalando e Rodando
 		$ git clone git@github.com:pyladies-brazil/br-pyladies-pelican.git
 
 - Instale os requisitos de python via pip com o comando:
-> Obs.: Esse comando criará uma vm, então rode-o fora de qualquer vm.
+> Obs.: Esse comando criará uma virtual env, então rode-o fora de qualquer ambiente virtual.
 
 		$ make install
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Instalando e Rodando
 		$ git clone git@github.com:pyladies-brazil/br-pyladies-pelican.git
 
 - Instale os requisitos de python via pip com o comando:
+> Obs.: Esse comando criará uma vm, então rode-o fora de qualquer vm.
 
 		$ make install
 


### PR DESCRIPTION
Adição de uma observação indicando que o comando "make install" deve ser rodado fora de qualquer vm.