### PR TITLE
Replace Google Plus to Youtube

### DIFF
--- a/themes/default/templates/footer.html
+++ b/themes/default/templates/footer.html
@@ -11,12 +11,7 @@
                 <i class="fa fa-twitter fa-stack-1x"></i>
             </span>
         </a>
-        <a target="_blank" href="https://plus.google.com/114419825361109783805" data-toggle="tooltip" title="Google Plus">
-            <span class="fa-stack fa-lg">
-                <i class="fa fa-circle fa-stack-2x fa-inverse"></i>
-                <i class="fa fa-google-plus fa-stack-1x"></i>
-            </span>
-        </a>
+        
         <a target="_blank" href="http://github.com/pyladies-brazil" data-toggle="tooltip" title="Github">
             <span class="fa-stack fa-lg">
                 <i class="fa fa-circle fa-stack-2x fa-inverse"></i>
@@ -29,6 +24,14 @@
                 <i class="fa fa-facebook fa-stack-1x"></i>
             </span>
         </a>
+
+        <a target="_blank" href="https://www.youtube.com/c/BrazilPyLadies" data-toggle="tooltip" title="Youtube">
+            <span class="fa-stack fa-lg">
+                <i class="fa fa-circle fa-stack-2x fa-inverse"></i>
+                <i class="fa fa-youtube-square fa-stack-1x"></i>
+            </span>
+        </a>
+
         <a target="_blank" href="https://www.instagram.com/pyladiesbrasil/" data-toggle="tooltip" title="Instagram">
             <span class="fa-stack fa-lg">
                 <i class="fa fa-circle fa-stack-2x fa-inverse"></i>


### PR DESCRIPTION
@anapaulamendes Oiii
No footer, substituí o Google Plus pelo Youtube. O Google Plus não existe mais desde abril/2019