### PR TITLE
Parametriza SITEURL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ output
 
 # Virtualenv
 .venv
+venv
 
 # Temporary
 *.yml~

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -9,7 +9,7 @@ import yaml
 
 AUTHOR = u'Pyladies'
 SITENAME = u'Pyladies Brasil'
-SITEURL = '{}'.format(os.getenv('SITEURL', 'http://localhost:{}'.format(os.getenv('PORT', '8000'))))
+SITEURL = f"{os.getenv('SITEURL', 'http://localhost')}:{os.getenv('PORT', '8000')}"
 TAGLINE = (u'Ninguém pode fazer você se sentir inferior'
            'sem o seu consentimento (Eleanor Roosevelt)')
 DEFAULT_DATE_FORMAT = ('%d-%m-%Y')

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -9,7 +9,7 @@ import yaml
 
 AUTHOR = u'Pyladies'
 SITENAME = u'Pyladies Brasil'
-SITEURL = f"{os.getenv('SITEURL', 'http://localhost')}:{os.getenv('PORT', '8000')}"
+SITEURL = '{}'.format(os.getenv('SITEURL', 'http://localhost:{}'.format(os.getenv('PORT', '8000'))))
 TAGLINE = (u'Ninguém pode fazer você se sentir inferior'
            'sem o seu consentimento (Eleanor Roosevelt)')
 DEFAULT_DATE_FORMAT = ('%d-%m-%Y')

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -9,7 +9,7 @@ import yaml
 
 AUTHOR = u'Pyladies'
 SITENAME = u'Pyladies Brasil'
-SITEURL = 'http://localhost:{}'.format(os.getenv('PORT', '8000'))
+SITEURL = '{}'.format(os.getenv('SITEURL', 'http://localhost:8000'))
 TAGLINE = (u'Ninguém pode fazer você se sentir inferior'
            'sem o seu consentimento (Eleanor Roosevelt)')
 DEFAULT_DATE_FORMAT = ('%d-%m-%Y')

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -9,7 +9,7 @@ import yaml
 
 AUTHOR = u'Pyladies'
 SITENAME = u'Pyladies Brasil'
-SITEURL = '{}'.format(os.getenv('SITEURL', 'http://localhost:8000'))
+SITEURL = '{}'.format(os.getenv('SITEURL', 'http://localhost:{}'.format(os.getenv('PORT', '8000'))))
 TAGLINE = (u'Ninguém pode fazer você se sentir inferior'
            'sem o seu consentimento (Eleanor Roosevelt)')
 DEFAULT_DATE_FORMAT = ('%d-%m-%Y')

--- a/themes/default/templates/head.html
+++ b/themes/default/templates/head.html
@@ -25,7 +25,7 @@
 
 {% if page %}
 <!--Load Mathjax-->
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
         <script>
         MathJax.Hub.Config({
             config: ["MMLorHTML.js"],


### PR DESCRIPTION
**Descrição do PR**
Esse PR adiciona a possibilidade de parametrizar o SITEURL do Pelican sem ter a necessidade de utilizar o publishconf.py, para que o deploys previews feitos via netlify consigam usar a variável de ambiente da URL auto-gerada para o deploy preview.

**Descrição das mudanças**
Adicionei uma variável de ambiente para ser passada quando for utilizado o comando `pelican content`, sem quebrar a compatibilidade com o uso anterior da variável PORT para builds locais.
Essa variável, chamada SITEURL, pode ser setada ao gerar o conteudo estático do site para que as URLs de conteúdos estáticos utilizem ela como base.

**Screenshot**
Teste no netlify usando o romantic darwin carregando imagens da URL correta
![Screenshot from 2020-05-10 14-16-11](https://user-images.githubusercontent.com/1480558/81505867-de5d6a80-92c8-11ea-9103-a777b5dd2812.png)
![Screenshot from 2020-05-10 14-15-57](https://user-images.githubusercontent.com/1480558/81505868-def60100-92c8-11ea-873a-d4c1ee086809.png)


**Confirmações**
Antes de enviar o Pull Request, faça as seguintes confirmações
- [x] O PR foi testado localmente
- [x] (se aplicável) Nenhum link está quebrado
- [x] (se aplicável) Nenhuma imagem está quebrada

**Contexto adicional**
Adicione aqui qualquer informação que você considera importante ou que as
revisoras devam se atentar no processo de análise.
