### PR TITLE
Refatora pagina inicial, tornando-a uma lista de posts

### DIFF
--- a/themes/default/static/css/style.css
+++ b/themes/default/static/css/style.css
@@ -511,32 +511,27 @@ main, .notepad-share-icons, .notepad-disqus {
       padding-bottom: 12.5rem; } }
 
 .notepad-content .notepad-index-post .post-header {
-    min-height: 93px;
     margin-bottom: 2%; }
 
     @media only screen and (min-width: 40.063em) {
         .notepad-content .notepad-index-post .post-header {
           margin-bottom: 0; } }
     .notepad-content .notepad-index-post {
-      min-height: 300px;
-      margin-top: 3.375rem;
-      margin-bottom: 3px; }
+      margin-top: 2rem;
+      margin-bottom: 0.5rem; }
 
     .notepad-post-meta {
       display: inline-block;
     }
     .notepad-content .notepad-index-post .notepad-post-meta .day {
       display: block;
-      font-size: 3.25rem;
+      font-size: 1rem;
       font-weight: 800;
       color: #ff3373;
-      font-family: "Montserrat", sans-serif; }
-    .notepad-content .notepad-index-post .notepad-post-meta .month-year {
-      display: block;
-      font-size: 1rem;
-      color: #262626;
-      font-size: 0.875rem;
-      font-family: "Montserrat", sans-serif;}
+      font-family: "Montserrat", sans-serif; 
+      text-transform: capitalize;}
+      .notepad-content .notepad-index-post .notepad-post-meta .day a {
+        color: #ff3373; }
   .notepad-content .notepad-index-post .notepad-post-header .notepad-post-title {
     color: #262626;
     font-weight: 500;
@@ -563,6 +558,8 @@ main, .notepad-share-icons, .notepad-disqus {
     .notepad-content .notepad-index-post .notepad-post-excerpt p {
       margin: 0;
       font-size: 15px; }
+    .notepad-content .notepad-index-post .notepad-post-excerpt a {
+      color: black; }
   @media only screen and (min-width: 40.063em) {
     .notepad-content .notepad-index-post .notepad-post-excerpt {
       text-align: left; } }

--- a/themes/default/templates/index.html
+++ b/themes/default/templates/index.html
@@ -2,44 +2,37 @@
 {% block content %}
 {% if articles %}
 {% for post in articles_page.object_list[:6] %}
-
-<article class="notepad-index-post post small-12 medium-6 large-4 columns">
+<article class="notepad-index-post post small-12 medium-12 large-12">
   <div class="post-header row">
-    <span class="small-3 columns notepad-post-meta">
+    <span class="small-10 columns notepad-post-meta">
       <time datetime="{{ post.date.isoformat() }}">
-        <span class="day">
-          {{ post.date.strftime("%d") }}
-        </span>
-        <span class="month-year">
-          {{ post.date.strftime("%B %Y") }}
+        <span class="day">{{ post.date.strftime("%d %B %Y") }} -
+          <a href="{{ SITEURL }}/{{ post.url }}">
+            {{ post.title|striptags }}
+          </a>
         </span>
       </time>
     </span>
-    <span class="small-9 columns notepad-post-header">
-      <h3 class="notepad-post-title">
-        <a href="{{ SITEURL }}/{{ post.url }}">
-          {{ post.title|striptags }}
-        </a>
-      </h3>
-    </span>
   </div>
-
   <div class="row">
     <section class="small-12 columns notepad-post-excerpt">
-      <p>{{ post.summary }}</p>
+      <a href="{{ SITEURL }}/{{ post.url }}">
+        <p>{{ post.summary }}</p>
+      </a>
     </section>
-
     <div class="small-12 columns notepad-index-post-tags">
       {% if post.category %}
-      <a href="{{ SITEURL }}/category/{{ post.category|lower }}.html" title="Other posts from the {{ post.category|capitalize }} category">{{ post.category|capitalize }}</a>
+      <a href="{{ SITEURL }}/category/{{ post.category|lower }}.html"
+        title="Other posts from the {{ post.category|capitalize }} category">{{ post.category|capitalize }}</a>
       {% endif %}
     </div>
   </div>
+  <hr />
 </article>
 {% endfor %}
-<!--<nav class="pagination" role="navigation">-->
-  <!--<a class="newer-posts" href="{{ SITEURL }}/archives">View All Posts</a>-->
-<!--</nav>-->
+<!-- <nav class="pagination" role="navigation">
+  <a class="newer-posts" href="{{ SITEURL }}/archives">Ver todos os posts</a>
+</nav> -->
 {% else %}
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
**Descrição do PR**
Refatora pagina inicial, tornando-a uma lista de posts. Esse PR fecha a issue #361 da forma mais criativa que consegui fazer sem saber muito sobre front-end :P 
Em geral, também prefiro blogs com listas ao invés de blocos, então fica a sugestão. Fechem esse PR se não concordarem.

**Descrição das mudanças**
Mexi nums CSS aqui e ali e no html da pagina inicial.

**Screenshot**
![Screenshot from 2020-07-19 12-53-23](https://user-images.githubusercontent.com/1480558/87879093-dbfd4800-c9be-11ea-9da8-55ad85b8bd02.png)


**Confirmações**
- [x] O PR foi testado localmente
- [x] (se aplicável) Nenhum link está quebrado
- [x] (se aplicável) Nenhuma imagem está quebrada

**Contexto adicional**
Acho que é importante ver o preview no netlify e navegar um pouco, clicar nums posts, etc.