### PR TITLE
fix: adiciona padding a página de postagens

### DIFF
--- a/themes/default/static/css/style.css
+++ b/themes/default/static/css/style.css
@@ -518,7 +518,10 @@ main, .notepad-share-icons, .notepad-disqus {
           margin-bottom: 0; } }
     .notepad-content .notepad-index-post {
       margin-top: 2rem;
-      margin-bottom: 0.5rem; }
+      margin-bottom: 0.5rem;
+      padding-left: 2%;
+      padding-right: 2%;
+    }
 
     .notepad-post-meta {
       display: inline-block;


### PR DESCRIPTION
**Descrição do PR**
O site do PyLadies Brasil atualmente deixa as postagens sem margem nenhuma quando a tela fica de um formato xyz que só a @cecivieira sabe dizer. O PR corrige isso.

**Descrição das mudanças**
- adição de um padding à esquerda e um à direita

**Screenshot**
* Antes
![Antes](https://user-images.githubusercontent.com/12520431/90296629-64f28c80-de62-11ea-8160-5d0deb1faa4f.png)

* Depois
![Depois](https://user-images.githubusercontent.com/12520431/90296484-f8778d80-de61-11ea-8517-0810cebcf146.png)


**Confirmações**
Antes de enviar o Pull Request, faça as seguintes confirmações
- [x] O PR foi testado localmente
- [x] Nenhuma imagem está quebrada