### PR TITLE
Adiciona informação sobre o uso de uma porta alternativa

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ $ make up
 
 Abra o browser em [localhost:8000](http://localhost:8000) para ver o conteúdo gerado.
 
+**Observação**: Se sua porta 8000 já estiver em uso, você pode especificar uma porta diferente ao
+usar o parâmetro `PORT`. Por exemplo:
+
+```console
+$ make up PORT=8001
+```
+
+E então acessar [localhost:8001](http://localhost:8001). Atenção! Algumas [portas são reservadas](https://pt.wikipedia.org/wiki/Lista_de_portas_dos_protocolos_TCP_e_UDP).
+
 Links Úteis
 -----------
 


### PR DESCRIPTION
**Descrição do PR**
Esses dias eu tentei mudar a porta do Makefile na mão e aí nada rodou hehehe fuçando lá, descobri esse parâmetro PORT que dá pra usar quando sua porta já estiver em uso. Adicionei isso na documentação. 

**Descrição das mudanças**
* Adição de pequeno trecho explicando como rodar o projeto usando outra porta

**Confirmações**
Antes de enviar o Pull Request, faça as seguintes confirmações
- [x] O PR foi testado localmente
- [x] (se aplicável) Nenhum link está quebrado
- [x] (se aplicável) Nenhuma imagem está quebrada

**Contexto adicional**
Não sei se compensa mais fazer uma pequena seção de troubleshooting ou se a gente pode deixar o trecho onde está. Também não sei se esse trecho é realmente necessário hahah. Podemos conversar sobre. :heart: 
