### PR TITLE
fix: remove link quebrado do MacOS e trecho que se referia a ele

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,8 +73,6 @@ Preparando o ambiente local
 --------------------------
 - Antes de mais nada, verifique se você tem o **Python 3.6.4** instalado na sua máquina.
 
-(Atenção: se você estiver usando um **MacOS X** para desenvolver, você provavelmente precisará exportar algumas variáveis locale do Python. Siga esse link: [Fix unknown locale](http://patrick.arminio.info/fix-valueerror-unknown-locale-utf8/))
-
 Para criar um `virtualenv` e instalar os pacotes necessários para rodar o projeto,
 siga as orientações do capítulo "Instalando e Rodando" do [README](https://github.com/pyladies-brazil/br-pyladies-pelican/blob/master/README.md)
 

--- a/README.md
+++ b/README.md
@@ -154,4 +154,9 @@ Links Úteis
 * [pyenv](https://github.com/yyuu/pyenv)
 * [virtualenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/)
 
+Dúvidas?
+---------
+
+Qualquer dúvida ou problema durante a instalação, abra uma [issue](https://github.com/pyladies-brazil/br-pyladies-pelican/issues/new/choose)!
+
 Esse repositório é mantido com :heart: pelo @pyladies-brazil/tech-team


### PR DESCRIPTION
**Descrição das mudanças**
* remove link quebrado sobre problema de `unknown locale`
* insere trecho reforçando a abertura de uma issue caso haja problemas de instalação

**Confirmações**
- [x] O PR foi testado localmente
- [x] (se aplicável) Nenhum link está quebrado

**Contexto adicional**
closes #420 