### PR TITLE
traduz data para pt-BR (#427)

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -29,7 +29,7 @@ DIRECT_TEMPLATES = ('index', 'tags', 'categories', 'archives', 'sitemap')
 SITEMAP_SAVE_AS = 'sitemap.xml'
 
 TIMEZONE = 'America/Sao_Paulo'
-DEFAULT_LANG = u'en'
+DEFAULT_LANG = u'pt-br'
 THEME = 'themes/default'
 
 PATH = 'content'
@@ -52,6 +52,12 @@ MENUITEMS = (
 DEFAULT_PAGINATION = 10
 
 READERS = {'html': None}
+
+# DATE_FORMATS = {
+#     'pt': ('pt_BR': '%d-%m-%Y'),
+#     'en': ('en_US','%a, %d %b %Y'),
+#     'jp': ('ja_JP','%Y-%m-%d(%a)'),
+# }
 
 STATIC_PATHS = [
     'images',

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -53,12 +53,6 @@ DEFAULT_PAGINATION = 10
 
 READERS = {'html': None}
 
-# DATE_FORMATS = {
-#     'pt': ('pt_BR': '%d-%m-%Y'),
-#     'en': ('en_US','%a, %d %b %Y'),
-#     'jp': ('ja_JP','%Y-%m-%d(%a)'),
-# }
-
 STATIC_PATHS = [
     'images',
     'extra/robots.txt',


### PR DESCRIPTION
**Descrição do PR**
resolve #427 , traduzindo as datas para português brasileiro.

**Descrição das mudanças**
* alteração na linguagem padrão do site (`pelicanconf.py`) 

**Screenshot**
Antes
![image](https://github.com/pyladies-brazil/br-pyladies-pelican/assets/12520431/152d01dc-5eab-4f2f-896e-1115f6853d09)

Depois
![image](https://github.com/pyladies-brazil/br-pyladies-pelican/assets/12520431/30676380-5ac9-4bf1-b228-6b46db53e0eb)


**Confirmações**
Antes de enviar o Pull Request, faça as seguintes confirmações
- [X] O PR foi testado localmente
- [x] Nenhum link está quebrado
- [x] Nenhuma imagem está quebrada